### PR TITLE
feat(make): explicit podman commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 all:build-image
 
 build-image:
-	podman manifest rm python-generic:latest
-	podman build --jobs=2 --platform=linux/amd64,linux/arm64 --manifest python-generic:latest .
+	podman build  --jobs=2 --platform=linux/amd64 -t python-generic:latest-amd64 .
+	podman build  --jobs=2 --platform=linux/arm64 -t python-generic:latest-arm64 .
+	podman manifest rm python-generic:latest || true
+	podman manifest create python-generic:latest
+	podman manifest add --arch amd64 python-generic:latest python-generic:latest-amd64
+	podman manifest add --arch arm64 python-generic:latest python-generic:latest-arm64


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `Makefile` to build separate `amd64` and `arm64` images and create a manifest using Podman.
> 
>   - **Makefile Changes**:
>     - Modify `build-image` target to build separate images for `amd64` and `arm64` using `podman build`.
>     - Add `podman manifest create` and `podman manifest add` commands to create and populate a manifest for `python-generic:latest`.
>     - Ensure `podman manifest rm` is non-failing with `|| true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tolemi-inc%2Fpython_generic_container&utm_source=github&utm_medium=referral)<sup> for ade64d336535db6d0426941898b4a8261ec4f202. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->