### PR TITLE
change how we access config fields

### DIFF
--- a/python-generic/aws.py
+++ b/python-generic/aws.py
@@ -15,11 +15,11 @@ def set_aws_credentials(aws_access_key_id, aws_secret_access_key):
 
 def get_secret(config, secret_name):
     #get relevant config fields
-    aws_credentials = config['aws_creds']
-    city_alias = config['city_alias']
+    aws_credentials = config.aws_creds
+    city_alias = config.city_alias
 
     #retrieve secret with value
-    client = set_aws_credentials(aws_credentials['aws_access_key_id'], aws_credentials['aws_secret_key'])
+    client = set_aws_credentials(aws_credentials.aws_access_key_id, aws_credentials.aws_secret_key)
     secret = client.get_secret_value(SecretId = f'cities/{city_alias}/{secret_name}')
     return secret
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change config field access in `get_secret` in `aws.py` from dictionary-style to attribute-style.
> 
>   - **Behavior**:
>     - Change access method for config fields in `get_secret` in `aws.py` from dictionary-style to attribute-style.
>     - Affects retrieval of `aws_creds` and `city_alias` fields.
>   - **Functions**:
>     - `get_secret` now accesses `aws_credentials` and `city_alias` using dot notation.
>     - `set_aws_credentials` remains unchanged but is affected by the new access method for credentials.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tolemi-inc%2Fpython_generic_container&utm_source=github&utm_medium=referral)<sup> for a9c671de69c3bf205fa634278f45004a5a044094. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->