### PR TITLE
Config - add dict-like access

### DIFF
--- a/python-generic/main.py
+++ b/python-generic/main.py
@@ -126,6 +126,21 @@ class Config:
         else:
             self._city_alias = value
 
+    # Allow dict-like access for init attributes
+    def __getitem__(self, key):
+        # Map keys to properties/attributes
+        if key in ['data_file_path', 'script', 'aws_creds', 'city_alias', 'instance_bounding_box']:
+            return getattr(self, key)
+        else:
+            raise KeyError(f"Key '{key}' not found.")
+
+    # Allow dict-like assignment as well
+    def __setitem__(self, key, value):
+        if key in ['data_file_path', 'script', 'aws_creds', 'city_alias', 'instance_bounding_box']:
+            setattr(self, key, value)
+        else:
+            raise KeyError(f"Key '{key}' not found.")
+
 
 # Main Program
 if __name__ == "__main__":

--- a/python-generic/main.py
+++ b/python-generic/main.py
@@ -75,6 +75,8 @@ class ConfigError(Exception):
 
 
 class Config:
+    KEYS = ['data_file_path', 'script', 'aws_creds', 'city_alias', 'instance_bounding_box']
+    
     def __init__(self, data_file_path, script, aws_creds, city_alias, instance_bounding_box):
         self.data_file_path = data_file_path
         self.script = script
@@ -90,8 +92,7 @@ class Config:
     def data_file_path(self, value):
         if value is None:
             raise ConfigError("Missing data file path in config.")
-        else:
-            self._data_file_path = value
+        self._data_file_path = value
 
     @property
     def script(self):
@@ -101,8 +102,7 @@ class Config:
     def script(self, value):
         if value is None:
             raise ConfigError("Missing script in config.")
-        else:
-            self._script = value
+        self._script = value
 
     @property
     def aws_creds(self):
@@ -112,34 +112,20 @@ class Config:
     def aws_creds(self, value):
         if value is None:
             raise ConfigError("Missing aws credentials in env.")
-        else:
-            self._aws_creds = value
+        self._aws_creds = value
 
-    @property
-    def city_alias(self):
-        return self._city_alias
-
-    @city_alias.setter
-    def city_alias(self, value):
-        if value is None:
-            raise ConfigError("Missing city alias.")
-        else:
-            self._city_alias = value
-
-    # Allow dict-like access for init attributes
+    # Dictionary-like access
     def __getitem__(self, key):
-        # Map keys to properties/attributes
-        if key in ['data_file_path', 'script', 'aws_creds', 'city_alias', 'instance_bounding_box']:
+        if key in Config.KEYS:
             return getattr(self, key)
-        else:
-            raise KeyError(f"Key '{key}' not found.")
+        raise KeyError(f"Key '{key}' not found.")
 
-    # Allow dict-like assignment as well
     def __setitem__(self, key, value):
-        if key in ['data_file_path', 'script', 'aws_creds', 'city_alias', 'instance_bounding_box']:
+        if key in Config.KEYS:
             setattr(self, key, value)
         else:
             raise KeyError(f"Key '{key}' not found.")
+
 
 
 # Main Program


### PR DESCRIPTION
Adds dict-like access and assignment capability
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add dict-like access and assignment to `Config` class in `main.py`.
> 
>   - **Behavior**:
>     - Adds `__getitem__` to `Config` class in `main.py` for dict-like access to attributes `data_file_path`, `script`, `aws_creds`, `city_alias`, `instance_bounding_box`.
>     - Adds `__setitem__` to `Config` class in `main.py` for dict-like assignment to the same attributes.
>     - Raises `KeyError` for invalid keys in both methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tolemi-inc%2Fpython_generic_container&utm_source=github&utm_medium=referral)<sup> for e28c3aeab8e50bdbc9111210ea180bdc01bc5f7e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->