### PR TITLE
add raw config to python config

### DIFF
--- a/python-generic/main.py
+++ b/python-generic/main.py
@@ -50,7 +50,7 @@ def load_config(file_path):
     city_alias = raw_config.get('cityAlias')
     instance_bounding_box = raw_config.get('boundingBox')
 
-    return Config(data_file_path, script, aws_creds, city_alias, instance_bounding_box)
+    return Config(data_file_path, script, aws_creds, city_alias, instance_bounding_box, raw_config=raw_config)
 
 
 def load_json(file_path):
@@ -77,12 +77,13 @@ class ConfigError(Exception):
 class Config:
     KEYS = ['data_file_path', 'script', 'aws_creds', 'city_alias', 'instance_bounding_box']
     
-    def __init__(self, data_file_path, script, aws_creds, city_alias, instance_bounding_box):
+    def __init__(self, data_file_path, script, aws_creds, city_alias, instance_bounding_box, raw_config=None):
         self.data_file_path = data_file_path
         self.script = script
         self.aws_creds = aws_creds
         self.city_alias = city_alias
         self.instance_bounding_box = instance_bounding_box
+        self.raw_config = raw_config
 
     @property
     def data_file_path(self):


### PR DESCRIPTION
Give raw config access (optional) to config object passed to Container
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add optional `raw_config` parameter to `Config` class and update `load_config()` to pass it.
> 
>   - **Config Class**:
>     - Add optional `raw_config` parameter to `__init__` in `Config` class.
>     - Store `raw_config` in `self.raw_config`.
>   - **load_config Function**:
>     - Update `load_config()` to pass `raw_config` to `Config` constructor.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=tolemi-inc%2Fpython_generic_container&utm_source=github&utm_medium=referral)<sup> for 5c63179400461329329762161cdd0d837b28cbd7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->